### PR TITLE
Bumped version to 0.3.0-pre2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gpio-adapter",
-  "version": "0.2.1",
+  "version": "0.3.0-pre2",
   "description": "GPIO adapter plugin for Mozilla IoT Gateway",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
Fixes gateway master.

I've already created a 0.3.0-pre2 release based on this in order to fix test breakage on master.